### PR TITLE
Minify documents before adding it to the output

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     },
     "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.3.1",
-        "@graphql-codegen/visitor-plugin-common": "^2.5.0"
+        "@graphql-codegen/visitor-plugin-common": "^2.5.0",
+        "gqlmin": "^0.1.1"
     },
     "devDependencies": {
         "graphql": "^16.0.1",

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -25,7 +25,7 @@ export class GraphQLHooksVisitor extends ClientSideBaseVisitor<
             fragments,
             rawConfig,
             {
-                //Dont include documents in the output, as we will add them manually instead
+                // Don't include documents in the output, as we will add them manually instead
                 documentMode: DocumentMode.external,
                 ...additionalConfig,
             },

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -25,7 +25,7 @@ export class GraphQLHooksVisitor extends ClientSideBaseVisitor<
             fragments,
             rawConfig,
             {
-                //Dont include it in the output
+                //Dont include documents in the output, as we will add them manually instead
                 documentMode: DocumentMode.external,
                 ...additionalConfig,
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,6 +655,11 @@
   dependencies:
     tslib "~2.3.0"
 
+"@types/moo@^0.5.3":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@types/moo/-/moo-0.5.7.tgz#5ee2ae00163e4d673208997e9f8495f276ca8f7a"
+  integrity sha512-P7vrZaxja4ne72cKKx3C4ixuNftUIJllGHDHUfUJDqImIihnHzBkz28DDaPOQE3XQODo+k3NDCziP8f0V6yphQ==
+
 ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
@@ -1069,6 +1074,14 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+gqlmin@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/gqlmin/-/gqlmin-0.1.1.tgz#7efac357d276e0bd70cbc87ec9012fa5f6b45e09"
+  integrity sha512-Is0baa/66J5lwU2wnfXpA/SjtCzCxhVW6s03HSYgirbK1UmE549S4Ylev+MF4MLBip+KhsRwk1xSr1zKTSSTUQ==
+  dependencies:
+    "@types/moo" "^0.5.3"
+    moo "^0.5.1"
+
 graphql-tag@^2.11.0:
   version "2.12.4"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.4.tgz#d34066688a4f09e72d6f4663c74211e9b4b7c4bf"
@@ -1253,6 +1266,11 @@ minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+moo@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
The `documentMode` `DocumentMode.string,` causes it to be added as a prettified string. Normally you would change the mode to `documentNode` to get the documentNode as a JSON object.
This does however not work because `graphql-hooks` only accepts the document as a string. 